### PR TITLE
Modificando a maneira como o nosso numero é gerado. Agora é de acordo…

### DIFF
--- a/src/Boleto/Banco/Sicredi.php
+++ b/src/Boleto/Banco/Sicredi.php
@@ -162,8 +162,12 @@ class Sicredi extends BancoAbstract
     public function setNossoNumeroFormatado(Boleto $boleto)
     {
         return $this->setNossoNumero(
-            date('y') . '/' . $this->getByte() . $boleto->getNossoNumero() . '-'
-            . $boleto->getDigitoVerificadorNossoNumero()
+            \sprintf("%s/%s%s-%s",
+                $boleto->getDataDocumento()->format('y'),
+                $this->getByte(),
+                $boleto->getNossoNumero(),
+                $boleto->getDigitoVerificadorNossoNumero()
+            )
         );
     }
 }

--- a/src/Boleto/Banco/Sicredi.php
+++ b/src/Boleto/Banco/Sicredi.php
@@ -30,7 +30,7 @@ class Sicredi extends BancoAbstract
     {
         // |Agência | Posto | Cedente | Ano | Byte | Sequencial(Nosso número) |
         $nnum = $boleto->getCedente()->getAgencia() . $this->getPosto() .
-            $boleto->getCedente()->getCodigoCedente() . date('y') . $this->getByte() . $boleto->getNossoNumero();
+            $boleto->getCedente()->getCodigoCedente() . $boleto->getDataDocumento()->format('y') . $this->getByte() . $boleto->getNossoNumero();
 
         //dv do nosso número
         return $this->digitoVerificadorNossonumero($nnum);
@@ -43,7 +43,7 @@ class Sicredi extends BancoAbstract
    */
     public function getNossoNumeroSemDigitoVerificador(Boleto $boleto)
     {
-        return date('y') . $this->getByte() . $boleto->getNossoNumero();
+        return $boleto->getDataDocumento()->format('y') . $this->getByte() . $boleto->getNossoNumero();
     }
 
   /**
@@ -53,7 +53,7 @@ class Sicredi extends BancoAbstract
    */
     public function getNossoNumeroComDigitoVerificador(Boleto $boleto)
     {
-        return date('y') . $this->getByte() . $boleto->getNossoNumero();
+        return $boleto->getDataDocumento()->format('y') . $this->getByte() . $boleto->getNossoNumero();
     }
 
   /**
@@ -63,7 +63,7 @@ class Sicredi extends BancoAbstract
    */
     public function getCarteiraENossoNumeroComDigitoVerificador(Boleto $boleto)
     {
-        return date('y') . '/' . $this->getByte() . $boleto->getNossoNumero() . '-'
+        return $boleto->getDataDocumento()->format('y') . '/' . $this->getByte() . $boleto->getNossoNumero() . '-'
             . $this->getNossoNumeroComDigitoVerificador($boleto);
     }
 


### PR DESCRIPTION
Saudações,
utilizo essa sensual biblioteca em meu projeto e me deparei com uma issue.

A composição do (Nosso Numero) utiliza a data atual para compor parte da string, mais precisamente os dois primeiros dígitos que são o ano ATUAL.
Após a vrada para 2020 notei em meu cliente que o numero enviado na remessa (feita no final de dezembro) estava com o ano de 2019, mas quando acessavamos o a visualização real time do boleto, notamos que divergia da remessa, pois está exibindo o 20.
Eu corrigi e estou criando este saudoso PR. Que a força esteja com você!

Att